### PR TITLE
fix crash on closed sound source operation

### DIFF
--- a/mod.lua
+++ b/mod.lua
@@ -394,7 +394,7 @@ if RequiredScript == "lib/units/beings/player/playerdamage" then
 			managers.memebangs:set_alpha(flashbang_progress)
 		end
 
-		if managers.memebangs.audio_source and not managers.memebangs.audio_source:is_active() then
+		if not managers.memebangs.audio_source or managers.memebangs.audio_source:is_closed() or not managers.memebangs.audio_source:is_active() then
 			return
 		end
 

--- a/mod.lua
+++ b/mod.lua
@@ -237,7 +237,7 @@ function FlashBangMemeger:stop_audio()
 		-- self.audio_buffer = nil
 	end
 
-	if self.audio_source then
+	if self.audio_source and not self.audio_source:is_closed() then
 		self.audio_source:stop()
 		-- self.audio_source:close(true)
 		-- self.audio_source = nil
@@ -245,7 +245,7 @@ function FlashBangMemeger:stop_audio()
 end
 
 function FlashBangMemeger:set_volume(volume)
-	if self.audio_source then
+	if self.audio_source and not self.audio_source:is_closed() then
 		self.audio_source:set_volume(volume)
 	end
 end


### PR DESCRIPTION
add a sanity check to prevent a crash that can occur when the audio source is closed, eg. after returning from custody

Addresses the following crash log: (edited for brevity)

```
Application has crashed: C++ exception
mods/base/req/xaudio/XAudioSource.lua:117: Cannot use closed resource!
SCRIPT STACK
get_state() @mods/base/req/xaudio/XAudioSource.lua:117
is_active() @mods/base/req/xaudio/XAudioSource.lua:99
func() @mods/PD2-Random-Flashbangs-main/mod.lua:397
```